### PR TITLE
Various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ run/
 .classpath
 .settings/
 
+# vscode
+.vscode/
+
 bin/
 
 oldSrc/

--- a/src/main/java/com/cumulusmc/artofalchemy/block/BlockPipe.java
+++ b/src/main/java/com/cumulusmc/artofalchemy/block/BlockPipe.java
@@ -249,7 +249,7 @@ public class BlockPipe extends Block implements NetworkElement, BlockEntityProvi
 	@Override
 	public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean notify) {
 		super.onStateReplaced(state, world, pos, newState, notify);
-		if (!world.isClient()) {
+		if (!world.isClient() && newState.getBlock() != this) {
 			EssentiaNetworker.get((ServerWorld) world).remove(pos, getConnectionsBlockless(world, pos));
 		}
 	}
@@ -272,6 +272,7 @@ public class BlockPipe extends Block implements NetworkElement, BlockEntityProvi
 		if (TagRegistry.item(ArtOfAlchemy.id("usable_on_pipes")).contains(heldStack.getItem())) {
 			return ActionResult.PASS;
 		}
+		Set<BlockPos> oldConnections = getConnections(world, pos);
 		IOFace face = getFace(world, pos, dir);
 		switch (face) {
 			case NONE:
@@ -308,7 +309,7 @@ public class BlockPipe extends Block implements NetworkElement, BlockEntityProvi
 		}
 		if (!world.isClient()) {
 			EssentiaNetworker networker = EssentiaNetworker.get((ServerWorld) world);
-			networker.remove(pos, getConnections(world, pos));
+			networker.remove(pos, oldConnections);
 			networker.add(pos);
 		}
 		return ActionResult.SUCCESS;

--- a/src/main/java/com/cumulusmc/artofalchemy/blockentity/BlockEntitySynthesizer.java
+++ b/src/main/java/com/cumulusmc/artofalchemy/blockentity/BlockEntitySynthesizer.java
@@ -397,9 +397,7 @@ public class BlockEntitySynthesizer extends BlockEntity implements ImplementedIn
 
 	@Override
 	public boolean canExtract(int slot, ItemStack stack, Direction dir) {
-		if (slot == 1) {
-			return TagRegistry.item(ArtOfAlchemy.id("containers")).contains(stack.getItem());
-		} else if (slot == 2) {
+		if (slot == 2) {
 			return world.isReceivingRedstonePower(pos);
 		} else {
 			return true;

--- a/src/main/java/com/cumulusmc/artofalchemy/item/ItemEssentiaPort.java
+++ b/src/main/java/com/cumulusmc/artofalchemy/item/ItemEssentiaPort.java
@@ -2,11 +2,17 @@ package com.cumulusmc.artofalchemy.item;
 
 import com.cumulusmc.artofalchemy.block.AoABlocks;
 import com.cumulusmc.artofalchemy.blockentity.BlockEntityPipe;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemUsageContext;
 import net.minecraft.item.Items;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
 
 public class ItemEssentiaPort extends Item {
 	public final BlockEntityPipe.IOFace IOFACE;
@@ -31,11 +37,23 @@ public class ItemEssentiaPort extends Item {
 
 	@Override
 	public ActionResult useOnBlock(ItemUsageContext context) {
-		if (context.getWorld().getBlockState(context.getBlockPos()).getBlock() == AoABlocks.PIPE) {
-			return context.getWorld().getBlockState(context.getBlockPos()).onUse(context.getWorld(), context.getPlayer(), context.getHand(),
-					new BlockHitResult(context.getHitPos(), context.getSide(), context.getBlockPos(), context.hitsInsideBlock()));
+		World world = context.getWorld();
+		BlockPos pos = context.getBlockPos();
+		BlockState state = world.getBlockState(pos);
+		Direction side = context.getSide();
+		PlayerEntity player = context.getPlayer();
+		if (state.getBlock() == AoABlocks.PIPE) {
+			return state.onUse(world, player, context.getHand(),
+				new BlockHitResult(context.getHitPos(), side, pos, context.hitsInsideBlock()));
 		} else {
-			return super.useOnBlock(context);
+			BlockPos offPos = pos.offset(side);
+			BlockState offState = world.getBlockState(offPos);
+			if (offState.getBlock() == AoABlocks.PIPE) {
+				return offState.onUse(world, player, context.getHand(),
+					new BlockHitResult(context.getHitPos(), player.isSneaking() ? side : side.getOpposite(),
+						offPos, context.hitsInsideBlock()));
+			}
 		}
+		return super.useOnBlock(context);
 	}
 }

--- a/src/main/java/com/cumulusmc/artofalchemy/mixin/MixinRecipeManager.java
+++ b/src/main/java/com/cumulusmc/artofalchemy/mixin/MixinRecipeManager.java
@@ -1,0 +1,32 @@
+package com.cumulusmc.artofalchemy.mixin;
+
+import java.util.Optional;
+
+import com.cumulusmc.artofalchemy.item.AoAItems;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeManager;
+import net.minecraft.recipe.RecipeType;
+import net.minecraft.util.collection.DefaultedList;
+import net.minecraft.world.World;
+
+@Mixin(RecipeManager.class)
+public abstract class MixinRecipeManager {
+
+	@Inject(at = @At(value = "RETURN", ordinal = 0), method = "getRemainingStacks", cancellable = true,
+		locals = LocalCapture.CAPTURE_FAILHARD)
+	private <C extends Inventory, T extends Recipe<C>> void replaceRemainingStacks(RecipeType<T> recipeType, C inventory,
+			World world, CallbackInfoReturnable<DefaultedList<ItemStack>> info, Optional<T> optional) {
+		if (optional.get().getOutput().getItem() == AoAItems.ALKAHEST_BUCKET) {
+			info.setReturnValue(DefaultedList.ofSize(inventory.size(), ItemStack.EMPTY));
+		}
+	}
+}

--- a/src/main/resources/artofalchemy.mixins.json
+++ b/src/main/resources/artofalchemy.mixins.json
@@ -4,7 +4,8 @@
   "package": "com.cumulusmc.artofalchemy.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
-    "RegistryAccessor"
+    "RegistryAccessor",
+    "MixinRecipeManager"
   ],
   "client": [
     "MixinClientRecipeBook"

--- a/src/main/resources/data/artofalchemy/recipes/crafting/alkahest_bucket.json
+++ b/src/main/resources/data/artofalchemy/recipes/crafting/alkahest_bucket.json
@@ -2,7 +2,6 @@
 	"type": "minecraft:crafting_shapeless",
 	"ingredients": [
 		{ "item":"minecraft:water_bucket" },
-		{ "item":"minecraft:bucket"},
 		{ "item":"minecraft:redstone" },
 		{ "item":"minecraft:glowstone_dust" },
 		{ "item":"minecraft:gunpowder" },

--- a/src/main/resources/data/artofalchemy/recipes/crafting/alkahest_bucket_from_azoth.json
+++ b/src/main/resources/data/artofalchemy/recipes/crafting/alkahest_bucket_from_azoth.json
@@ -2,7 +2,6 @@
 	"type": "minecraft:crafting_shapeless",
 	"ingredients": [
 		{ "item":"minecraft:water_bucket" },
-		{ "item":"minecraft:bucket"},
 		{ "item":"artofalchemy:azoth" }
 	],
 	"result": {


### PR DESCRIPTION
Fixed:
* Pipes not networking properly when toggling closed sides. Closes #26
* Alkahest recipe workaround, now crafted with a single water bucket instead of a water bucket and an empty bucket to deal with recipe remainders
* Hopper behavior for synthesis tables. Closes #22

Quality of life:
* Using an essentia port on the side of a block that faces a pipe now acts as if it was used on the opposite pipe face. In other words, you can attach ports by right clicking the block you want to connect to, rather than just the pipe.