### PR TITLE
Unopinionated 1.17 tag/material updates

### DIFF
--- a/src/main/resources/data/c/tags/items/amethysts.json
+++ b/src/main/resources/data/c/tags/items/amethysts.json
@@ -1,4 +1,6 @@
 {
   "replace": false,
-  "values": []
+  "values": [
+    "minecraft:amethyst_shard"
+  ]
 }

--- a/src/main/resources/data/c/tags/items/copper_ingots.json
+++ b/src/main/resources/data/c/tags/items/copper_ingots.json
@@ -1,4 +1,6 @@
 {
   "replace": false,
-  "values": []
+  "values": [
+    "minecraft:copper_ingot"
+  ]
 }


### PR DESCRIPTION
Adds 1.17 items to existing tags which were presumably setup for modded resource integration.

This change is not opinionated as it makes no changes to any essentia output, simply enables resources to function as intended.